### PR TITLE
bypass obsolete Instance for Pytest 7

### DIFF
--- a/pytest_relaxed/classes.py
+++ b/pytest_relaxed/classes.py
@@ -1,6 +1,5 @@
 import inspect
 import types
-from pathlib import Path
 
 import six
 
@@ -18,6 +17,7 @@ pytest_version_info = tuple(map(int, pytest_version.split(".")[:3]))
 if pytest_version_info < (7, 0, 0):
     from pytest import Instance
 else:
+    from pathlib import Path
     Instance = object
 
 # NOTE: these are defined here for reuse by both pytest's own machinery and our

--- a/pytest_relaxed/classes.py
+++ b/pytest_relaxed/classes.py
@@ -9,11 +9,7 @@ from pytest import Class, Module
 # the underscored name :(
 from _pytest.python import PyCollector
 
-try:
-    from pytest import version_tuple as pytest_version_info
-except ImportError:
-    from pytest import __version__ as pytest_version
-    pytest_version_info = tuple(map(int, pytest_version.split(".")[:3]))
+from .utils import pytest_version_info
 
 # https://docs.pytest.org/en/latest/deprecations.html#the-pytest-instance-collector
 # The pytest.Instance collector type has been removed in Pytest 7.0

--- a/pytest_relaxed/classes.py
+++ b/pytest_relaxed/classes.py
@@ -3,14 +3,17 @@ import types
 
 import six
 
-from pytest import __version__ as pytest_version
 from pytest import Class, Module
 
 # NOTE: don't see any other way to get access to pytest innards besides using
 # the underscored name :(
 from _pytest.python import PyCollector
 
-pytest_version_info = tuple(map(int, pytest_version.split(".")[:3]))
+try:
+    from pytest import version_tuple as pytest_version_info
+except ImportError:
+    from pytest import __version__ as pytest_version
+    pytest_version_info = tuple(map(int, pytest_version.split(".")[:3]))
 
 # https://docs.pytest.org/en/latest/deprecations.html#the-pytest-instance-collector
 # The pytest.Instance collector type has been removed in Pytest 7.0

--- a/pytest_relaxed/classes.py
+++ b/pytest_relaxed/classes.py
@@ -1,14 +1,24 @@
 import inspect
 import types
+from pathlib import Path
 
 import six
 
-from pytest import Class, Instance, Module
+from pytest import __version__ as pytest_version
+from pytest import Class, Module
 
 # NOTE: don't see any other way to get access to pytest innards besides using
 # the underscored name :(
 from _pytest.python import PyCollector
 
+pytest_version_info = tuple(map(int, pytest_version.split(".")[:3]))
+
+# https://docs.pytest.org/en/latest/deprecations.html#the-pytest-instance-collector
+# The pytest.Instance collector type has been removed in Pytest 7.0
+if pytest_version_info < (7, 0, 0):
+    from pytest import Instance
+else:
+    Instance = object
 
 # NOTE: these are defined here for reuse by both pytest's own machinery and our
 # internal bits.
@@ -19,6 +29,47 @@ def istestclass(name):
 def istestfunction(name):
     return not (name.startswith("_") or name in ("setup", "teardown"))
 
+def _get_obj_rec(obj, parent_obj):
+    # Obtain parent attributes, etc not found on our obj (serves as both a
+    # useful identifier of "stuff added to an outer class" and a way of
+    # ensuring that we can override such attrs), and set them on obj
+    delta = set(dir(parent_obj)).difference(set(dir(obj)))
+    for name in delta:
+        value = getattr(parent_obj, name)
+        # Pytest's pytestmark attributes always get skipped, we don't want
+        # to spread that around where it's not wanted. (Besides, it can
+        # cause a lot of collection level warnings.)
+        if name == "pytestmark":
+            continue
+        # Classes get skipped; they'd always just be other 'inner' classes
+        # that we don't want to copy elsewhere.
+        if isinstance(value, six.class_types):
+            continue
+        # Methods may get skipped, or not, depending:
+        if isinstance(value, types.MethodType):
+            # If they look like tests, they get skipped; don't want to copy
+            # tests around!
+            if istestfunction(name):
+                continue
+            # Non-test == they're probably lifecycle methods
+            # (setup/teardown) or helpers (_do_thing). Rebind them to the
+            # target instance, otherwise the 'self' in the setup/helper is
+            # not the same 'self' as that in the actual test method it runs
+            # around or within!
+            # TODO: arguably, all setup or helper methods should become
+            # autouse class fixtures (see e.g. pytest docs under 'xunit
+            # setup on steroids')
+            func = six.get_method_function(value)
+            setattr(obj, name, six.create_bound_method(func, obj))
+            continue
+        # Same as above but for Pytest 7 which does
+        # collect methods as functions, and without the six wrapper.
+        if isinstance(value, types.FunctionType) and istestfunction(name):
+            continue
+        # Anything else should be some data-type attribute, which is copied
+        # verbatim / by-value.
+        setattr(obj, name, value)
+    return obj
 
 # All other classes in here currently inherit from PyCollector, and it is what
 # defines the default istestfunction/istestclass, so makes sense to inherit
@@ -45,6 +96,15 @@ class RelaxedMixin(PyCollector):
 
 class SpecModule(RelaxedMixin, Module):
 
+    @classmethod
+    def from_parent(cls, parent, fspath):
+        if pytest_version_info >= (7, 0):
+            return super(SpecModule, cls).from_parent(parent, path=Path(fspath))
+        elif pytest_version_info >= (5, 4):
+            return super(SpecModule, cls).from_parent(parent, fspath=fspath)
+        else:
+            return cls(parent=parent, fspath=fspath)
+
     def _is_test_obj(self, test_func, obj, name):
         # First run our super() test, which should be RelaxedMixin's.
         good_name = getattr(super(SpecModule, self), test_func)(obj, name)
@@ -69,6 +129,7 @@ class SpecModule(RelaxedMixin, Module):
         # Get whatever our parent picked up as valid test items (given our
         # relaxed name constraints above). It'll be nearly all module contents.
         items = super(SpecModule, self).collect()
+
         collected = []
         for item in items:
             # Replace Class objects with recursive SpecInstances (via
@@ -80,28 +141,63 @@ class SpecModule(RelaxedMixin, Module):
             # them to be handled by pytest's own unittest support) but since
             # those are almost always in test_prefixed_filenames anyways...meh
             if isinstance(item, Class):
-                item = SpecClass(item.name, item.parent)
+                item = SpecClass.from_parent(item.parent, name=item.name)
             collected.append(item)
         return collected
 
 
-# NOTE: no need to inherit from RelaxedMixin here as it doesn't do much by
-# its lonesome
-class SpecClass(Class):
+class SpecClass(RelaxedMixin, Class):
+
+    @classmethod
+    def from_parent(cls, parent, name):
+        if pytest_version_info >= (5, 4):
+            return super(SpecClass, cls).from_parent(parent, name=name)
+        else:
+            return cls(parent=parent, name=name)
 
     def collect(self):
         items = super(SpecClass, self).collect()
         collected = []
-        # Replace Instance objects with SpecInstance objects that know how to
-        # recurse into inner classes.
-        # TODO: is this ever not a one-item list? Meh.
         for item in items:
-            item = SpecInstance(name=item.name, parent=item.parent)
-            collected.append(item)
+            if pytest_version_info < (7, 0):
+                # Replace Instance objects with SpecInstance objects that know how to
+                # recurse into inner classes.
+                item = SpecInstance.from_parent(item.parent, name=item.name)
+                collected.append(item)
+            else:
+                # Pytest >= 7 collects the Functions in Class directly without Instance
+                # Replace any Class objects with SpecClass, and recurse into it.
+                if isinstance(item, Class):
+                    subclass = SpecClass.from_parent(item.parent, name=item.name)
+                    collected += subclass.collect()
+                else:
+                    collected.append(item)
         return collected
 
+    def _getobj(self):
+        # Regular object-making first
+        obj = super(SpecClass, self)._getobj()
+        # Then decorate it with our parent's extra attributes, allowing nested
+        # test classes to appear as an aggregate of parents' "scopes".
+        # NOTE: of course, skipping if we've gone out the top into a module etc
+        if (
+            pytest_version_info < (7, 0)
+            or not hasattr(self, "parent")
+            or not isinstance(self.parent, SpecClass)
+        ):
+            return obj
+        else:
+            return _get_obj_rec(obj, self.parent.obj)
 
 class SpecInstance(RelaxedMixin, Instance):
+    # This is only instantiated in Pytest < 7
+
+    @classmethod
+    def from_parent(cls, parent, name):
+        if pytest_version_info >= (5, 4):
+            return super(SpecInstance, cls).from_parent(parent, name=name)
+        else:
+            return cls(parent=parent, name=name)
 
     def _getobj(self):
         # Regular object-making first
@@ -116,43 +212,9 @@ class SpecInstance(RelaxedMixin, Instance):
             or not isinstance(self.parent.parent, SpecInstance)
         ):
             return obj
-        parent_obj = self.parent.parent.obj
-        # Obtain parent attributes, etc not found on our obj (serves as both a
-        # useful identifier of "stuff added to an outer class" and a way of
-        # ensuring that we can override such attrs), and set them on obj
-        delta = set(dir(parent_obj)).difference(set(dir(obj)))
-        for name in delta:
-            value = getattr(parent_obj, name)
-            # Pytest's pytestmark attributes always get skipped, we don't want
-            # to spread that around where it's not wanted. (Besides, it can
-            # cause a lot of collection level warnings.)
-            if name == "pytestmark":
-                continue
-            # Classes get skipped; they'd always just be other 'inner' classes
-            # that we don't want to copy elsewhere.
-            if isinstance(value, six.class_types):
-                continue
-            # Functions (methods) may get skipped, or not, depending:
-            if isinstance(value, types.MethodType):
-                # If they look like tests, they get skipped; don't want to copy
-                # tests around!
-                if istestfunction(name):
-                    continue
-                # Non-test == they're probably lifecycle methods
-                # (setup/teardown) or helpers (_do_thing). Rebind them to the
-                # target instance, otherwise the 'self' in the setup/helper is
-                # not the same 'self' as that in the actual test method it runs
-                # around or within!
-                # TODO: arguably, all setup or helper methods should become
-                # autouse class fixtures (see e.g. pytest docs under 'xunit
-                # setup on steroids')
-                func = six.get_method_function(value)
-                setattr(obj, name, six.create_bound_method(func, obj))
-            # Anything else should be some data-type attribute, which is copied
-            # verbatim / by-value.
-            else:
-                setattr(obj, name, value)
-        return obj
+        else:
+            return _get_obj_rec(obj, self.parent.parent.obj)
+
 
     def collect(self):
         items = super(SpecInstance, self).collect()

--- a/pytest_relaxed/plugin.py
+++ b/pytest_relaxed/plugin.py
@@ -28,7 +28,7 @@ def pytest_collect_file(path, parent):
     ):
         # Then use our custom module class which performs modified
         # function/class selection as well as class recursion
-        return SpecModule(path, parent)
+        return SpecModule.from_parent(parent, fspath=path)
 
 
 @pytest.mark.trylast  # So we can be sure builtin terminalreporter exists

--- a/pytest_relaxed/utils.py
+++ b/pytest_relaxed/utils.py
@@ -1,0 +1,5 @@
+try:
+    from pytest import version_tuple as pytest_version_info
+except ImportError:
+    from pytest import __version__ as pytest_version
+    pytest_version_info = tuple(map(int, pytest_version.split(".")[:3]))

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         # TODO: do we need to name the LHS 'pytest_relaxed' too? meh
         "pytest11": ["relaxed = pytest_relaxed.plugin"]
     },
-    install_requires=["pytest>=3,<5", "six>=1,<2", "decorator>=4,<5"],
+    install_requires=["pytest>=3", "six>=1,<2", "decorator>=4,<5"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Pytest",

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,4 +1,5 @@
 from pytest import skip
+from pytest import __version__ as pytest_version
 
 # Load some fixtures we expose, without actually loading our entire plugin
 from pytest_relaxed.fixtures import environ  # noqa
@@ -7,6 +8,8 @@ from pytest_relaxed.fixtures import environ  # noqa
 # TODO: how best to make all of this opt-in/out? Reporter as separate plugin?
 # (May not be feasible if it has to assume something about how our collection
 # works?) CLI option (99% sure we can hook into that as a plugin)?
+
+pytest_version_info = tuple(map(int, pytest_version.split(".")[:3]))
 
 
 def _expect_regular_output(testdir):
@@ -225,7 +228,14 @@ OtherBehaviors
         assert "== FAILURES ==" in output
         assert "AssertionError" in output
         # Summary
-        assert "== 1 failed, 4 passed, 1 skipped in " in output
+        if pytest_version_info >= (5, 3):
+            expected_out = (
+                "== \x1b[31m\x1b[1m1 failed\x1b[0m, \x1b[32m4 passed\x1b[0m, "
+                "\x1b[33m1 skipped\x1b[0m\x1b[31m in "
+            )
+        else:
+            expected_out = "== 1 failed, 4 passed, 1 skipped in "
+        assert expected_out in output
 
     def test_nests_many_levels_deep_no_problem(self, testdir):
         testdir.makepyfile(

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,6 +1,8 @@
 from pytest import skip
 from pytest import __version__ as pytest_version
 
+from pytest_relaxed.utils import pytest_version_info
+
 # Load some fixtures we expose, without actually loading our entire plugin
 from pytest_relaxed.fixtures import environ  # noqa
 
@@ -8,9 +10,6 @@ from pytest_relaxed.fixtures import environ  # noqa
 # TODO: how best to make all of this opt-in/out? Reporter as separate plugin?
 # (May not be feasible if it has to assume something about how our collection
 # works?) CLI option (99% sure we can hook into that as a plugin)?
-
-pytest_version_info = tuple(map(int, pytest_version.split(".")[:3]))
-
 
 def _expect_regular_output(testdir):
     output = testdir.runpytest().stdout.str()


### PR DESCRIPTION
This will keep pytest-relaxed functioning for Tumbleweed through the pytest 7 update.

Meant as an addition to bitprophet/pytest-relaxed#21, hence the PR into the PR branch.